### PR TITLE
RDKB-60196: Subdoc Allows Timer Values Outside Expected Range

### DIFF
--- a/source/MeshAgentSsp/cosa_webconfig_api.c
+++ b/source/MeshAgentSsp/cosa_webconfig_api.c
@@ -655,7 +655,7 @@ bool  mesh_msgpack_decode(char* pString, int decode_size, eBlobType type)
                     publishRBUSEvent(CHANNEL_PLAN_COMMIT, (void *)"",handle);
                     channelplan_copy_to_global(channel_plan_data);
                 } else {
-                    MeshError("%s: Invalid channel plan blob received", __func__);
+                    MeshError("%s: Invalid channel plan blob received\n", __func__);
                     if (keepout_payload) {
                         free(keepout_payload);
                         keepout_payload = NULL;


### PR DESCRIPTION
Reason for change: Subdoc Allows Timer Values Outside Expected Range
Test Procedure: Ensure that the blob is not published if the expiry timestamp is not a valid 10-digit epoch time.
Risks: Low
Priority: P2
Signed-off-by: lavanya_chimmirivenkata@comcast.com

Change-Id: Ib2dae7a668c0dfb6acb009f9642ad6ed7aae1427
(cherry picked from commit a7519a040c0ccf1b808146b9def61d3895379992)