### PR TITLE
RDKB-60495,RDKB-60863 : Block eth wan port from adding vlan 200 in ethwan mode

### DIFF
--- a/source/MeshAgentSsp/cosa_apis_util.c
+++ b/source/MeshAgentSsp/cosa_apis_util.c
@@ -514,6 +514,23 @@ bool udhcpc_start(char* ifname)
     return true;
 }
 
+void remove_interface(char *eth_interface, char *eth_wan) {
+    char *token, *rest = eth_interface;
+    char result[ETH_IFNAME_MAX_LEN] = "";
+    int first = 1;
+
+    while ((token = strtok_r(rest, " ", &rest))) {
+        if (strcmp(token, eth_wan) != 0) {
+            if (!first) {
+                strncat(result, " ", sizeof(result) - strlen(result) - 1);
+            }
+            strncat(result, token, sizeof(result) - strlen(result) - 1);
+            first = 0;
+        }
+    }
+    strncpy(eth_interface, result, ETH_IFNAME_MAX_LEN - 1);
+}
+
 bool udhcpc_stop(char* ifname)
 {
     int pid = udhcpc_pid(ifname);

--- a/source/MeshAgentSsp/cosa_apis_util.h
+++ b/source/MeshAgentSsp/cosa_apis_util.h
@@ -115,6 +115,7 @@ BOOL is_bridge_mode_enabled();
 int getMeshErrorCode();
 void* handleMeshEnable(void *Args);
 void meshSetSyscfg(bool enable, bool commitSyscfg);
+void remove_interface(char *eth_interface, char * eth_wan);
 
 int Mesh_SyseventGetStr(const char *name, unsigned char *out_value, int outbufsz);
 int Mesh_SyseventSetStr(const char *name, unsigned char *value, int bufsz, bool toArm);

--- a/source/MeshAgentSsp/cosa_mesh_apis.c
+++ b/source/MeshAgentSsp/cosa_mesh_apis.c
@@ -2431,6 +2431,8 @@ get_eth_interface(char * eth_interface)
     char *val = NULL;
     int ret = false;
     int len = 0;
+    char buf[ 8 ] = { 0 };
+    char ethWanIfaceName[10] ={0} ;
 
     if (eth_interface == NULL)
     {
@@ -2446,6 +2448,22 @@ get_eth_interface(char * eth_interface)
             if(len > 0)
             {
                 snprintf(eth_interface, ETH_IFNAME_MAX_LEN, "%s", val);
+
+
+                if( 0 == syscfg_get( NULL, "eth_wan_enabled", buf, sizeof( buf ) ) )
+                {
+                    if ( strcmp (buf,"true") == 0 )
+                    {
+                        memset(buf,0,sizeof(buf));
+                        memset(ethWanIfaceName,0,sizeof(ethWanIfaceName));
+                        if( 0 == syscfg_get( NULL, "eth_wan_iface_name", ethWanIfaceName, sizeof( ethWanIfaceName ) ) )
+                        {
+                            remove_interface(eth_interface, ethWanIfaceName);
+                            MeshInfo("XB is in eth wan mode, removing eth wan interface %s updated interface list  %s\n",ethWanIfaceName, eth_interface);
+                        }
+                    }
+                }
+
                 ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(val);
                 ret = true;
             }

--- a/source/include/meshsync_msgs.h
+++ b/source/include/meshsync_msgs.h
@@ -51,8 +51,9 @@
 #define PRIV_BR              "brlan0"
 #define LNF_BR_XF3           "brlan6"
 
-#ifdef WAN_FAILOVER_SUPPORTED
 #define ETH_IFNAME_MAX_LEN   128
+
+#ifdef WAN_FAILOVER_SUPPORTED
 #define MESH_EXTENDER_VLAN   200
 #define MESH_ETHPORT        "eth"
 #endif


### PR DESCRIPTION
Reason for change: When the XLE is connected to the XB via Eth backhaul, the mesh adds all Ethernet ports with VLAN 200 and includes them in the brRWAN bridge. This behavior has been present from day one across Comcast and all partner devices.

However, due to a possible recent WAN rule change specific to partner devices, an issue has been observed: when the XB is operating in EthWAN mode and the XLE is connected via Ethernet backhaul, the addition of eth3.200 to the brRWAN bridge causes the EthWAN connection to fail.

Since eth3.200 is not required in EthWAN mode, this fix introduces a change to prevent the creation of eth3.200 in that scenario.

Test Procedure: check ovs-vsctl show
Risks: None
Priority: P1

Change-Id: I986c9b5b9d42b5756ab6e0d9200d628129c6e807

(cherry picked from commit ba35263edcc2f650d42ad1511d796cf86e12a0d7) (cherry picked from commit da285c5bb9d4f8cdb4541327b851c26a5496f2c6)