### PR TITLE
RDKB-60558 : AWS credentials being printed in plaintext in the logs

### DIFF
--- a/scripts/rdkbHCMRecordingMonitor.sh
+++ b/scripts/rdkbHCMRecordingMonitor.sh
@@ -136,7 +136,7 @@ UploadToAmazonS3()
     else
         forced_https="false"
     fi
-    RemSignature=`echo $Key | sed "s/AWSAccessKeyId=.*Signature=.*&//g;s/\"//g;s/.*https/https/g"`
+    RemSignature=`echo $Key | sed "s/\.mworec\?.*/\.mworec?<Hidden_Credentials>/g"`
     if [ "$encryptionEnable" != "true" ]; then
         Key=\"$Key\"
     fi


### PR DESCRIPTION
Reason for change: AWS credentials being printed in plaintext in the logs Test Procedure: Make sure no credentials are printed during HCM Recorder upload. Risks: Low
Priority: P1
Signed-off-by:lavanya_chimmirivenkata@comcast.com

Change-Id: I488cc0c5d3d71dff88748b1e41c17de1831cb865 (cherry picked from commit e67489a7a38ee1a0681672b423da9da37dffdbff)